### PR TITLE
feat: add adventurelog config

### DIFF
--- a/src/adventurelog/Caddyfile
+++ b/src/adventurelog/Caddyfile
@@ -1,0 +1,14 @@
+adventurelog.{env.DOMAIN_NAME} {
+    @frontend {
+        not path /media* /admin* /static* /accounts*
+    }
+    reverse_proxy @frontend {env.CLUSTER_IP}:{env.ADVENTURELOG_FRONTEND_PORT}
+
+    reverse_proxy {env.CLUSTER_IP}:{env.ADVENTURELOG_BACKEND_PORT}
+
+    encode gzip
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}

--- a/src/adventurelog/docker-compose.yml
+++ b/src/adventurelog/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  web:
+    image: ghcr.io/seanmorley15/adventurelog-frontend:latest
+    container_name: adventurelog_frontend
+    restart: unless-stopped
+    ports:
+      - ${FRONTEND_PORT}:3000
+    depends_on:
+      - server
+
+  db:
+    image: postgis/postgis:16-3.5
+    container_name: adventurelog_db
+    restart: unless-stopped
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+
+  server:
+    image: ghcr.io/seanmorley15/adventurelog-backend:latest
+    container_name: adventurelog_backend
+    restart: unless-stopped
+    ports:
+      - ${BACKEND_PORT}:80
+    depends_on:
+      - db
+    volumes:
+      - adventurelog_media:/code/media/
+
+volumes:
+  postgres_data:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${APPDATA_LOCATION}/postgres
+  adventurelog_media:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${APPDATA_LOCATION}/media

--- a/src/adventurelog/docker-compose.yml
+++ b/src/adventurelog/docker-compose.yml
@@ -3,8 +3,11 @@ services:
     image: ghcr.io/seanmorley15/adventurelog-frontend:latest
     container_name: adventurelog_frontend
     restart: unless-stopped
+    environment:
+      PUBLIC_SERVER_URL: http://server:8000
+      ORIGIN: ${ORIGIN}
     ports:
-      - ${FRONTEND_PORT}:3000
+      - ${FRONTEND_EXPOSED_PORT}:3000
     depends_on:
       - server
 
@@ -12,6 +15,10 @@ services:
     image: postgis/postgis:16-3.5
     container_name: adventurelog_db
     restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - postgres_data:/var/lib/postgresql/data/
 
@@ -19,8 +26,20 @@ services:
     image: ghcr.io/seanmorley15/adventurelog-backend:latest
     container_name: adventurelog_backend
     restart: unless-stopped
+    environment:
+      PGHOST: db
+      PGUSER: ${POSTGRES_USER}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      PGDATABASE: ${POSTGRES_DB}
+      SECRET_KEY: ${SECRET_KEY}
+      DJANGO_ADMIN_USERNAME: ${DJANGO_USERNAME}
+      DJANGO_ADMIN_PASSWORD: ${DJANGO_PASSWORD}
+      DJANGO_ADMIN_EMAIL: ${DJANGO_EMAIL}
+      PUBLIC_URL: https://adventurelog.${DOMAIN_NAME}
+      CSRF_TRUSTED_ORIGINS: https://adventurelog.${DOMAIN_NAME}
+      FRONTEND_URL: https://adventurelog.${DOMAIN_NAME}
     ports:
-      - ${BACKEND_PORT}:80
+      - ${BACKEND_EXPOSED_PORT}:80
     depends_on:
       - db
     volumes:

--- a/src/adventurelog/docker-compose.yml
+++ b/src/adventurelog/docker-compose.yml
@@ -33,9 +33,11 @@ volumes:
       type: 'none'
       o: 'bind'
       device: ${APPDATA_LOCATION}/postgres
+    external: true
   adventurelog_media:
     driver: local
     driver_opts:
       type: 'none'
       o: 'bind'
       device: ${APPDATA_LOCATION}/media
+    external: true


### PR DESCRIPTION
This pull request introduces infrastructure configuration files to support deployment and orchestration for the AdventureLog application. The changes add a `Caddyfile` for reverse proxy and TLS setup, and a `docker-compose.yml` for defining and managing the application's frontend, backend, and database services with persistent volumes.

**Infrastructure and Deployment Configuration:**

* Added `src/adventurelog/Caddyfile` to configure Caddy as a reverse proxy for both frontend and backend services, including TLS setup with Cloudflare DNS and gzip encoding.

* Added `src/adventurelog/docker-compose.yml` to define Docker services for frontend, backend, and database (PostGIS), including persistent volumes for database and media storage, service dependencies, and port mappings.