### PR TITLE
feat: add audiobookshelf config

### DIFF
--- a/src/audiobookshelf/Caddyfile
+++ b/src/audiobookshelf/Caddyfile
@@ -1,0 +1,9 @@
+audiobookshelf.{env.DOMAIN_NAME} {
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+
+    reverse_proxy {env.CLUSTER_IP}:{env.AUDIOBOOKSHELF_PORT}
+
+    encode gzip
+}

--- a/src/audiobookshelf/docker-compose.yml
+++ b/src/audiobookshelf/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  audiobookshelf:
+    container_name: audiobookshelf
+    image: advplyr/audiobookshelf:2.26.3
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 80 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    mem_limit: 4g
+    cpu_shares: 768
+    security_opt:
+      - no-new-privileges:true
+    restart: on-failure:5
+    ports:
+      - ${EXPOSE_PORT}:80
+    volumes:
+      - ${APPDATA_LOCATION}:/config:rw
+      - ${MEDIA_LOCATION}/books:/audiobooks:rw
+      - ${MEDIA_LOCATION}/podcasts:/podcasts:rw
+      - ${APPDATA_LOCATION}/metadata:/metadata:rw


### PR DESCRIPTION
This pull request introduces configuration files to deploy the Audiobookshelf service using Docker Compose and Caddy, enabling reverse proxying, TLS with Cloudflare DNS, resource limits, and health checks.

Audiobookshelf service deployment:

* Added a new `docker-compose.yml` for Audiobookshelf, specifying container settings, resource limits, health checks, volume mounts, and port mapping.

Reverse proxy and TLS configuration:

* Added a new Caddyfile configuration to set up a reverse proxy for Audiobookshelf, with TLS using Cloudflare DNS and gzip encoding.