### PR TITLE
feat: add Caddyfile for Technitium DNS reverse proxy

### DIFF
--- a/src/technitium_dns/Caddyfile
+++ b/src/technitium_dns/Caddyfile
@@ -1,7 +1,6 @@
 dns.{env.DOMAIN_NAME} {
     reverse_proxy {env.TECHNITIUM_DNS_IP}
 
-    encode gzip
 
     tls {
         dns cloudflare {env.CLOUDFLARE_API_TOKEN}

--- a/src/technitium_dns/Caddyfile
+++ b/src/technitium_dns/Caddyfile
@@ -1,0 +1,9 @@
+dns.{env.DOMAIN_NAME} {
+    reverse_proxy {env.TECHNITIUM_DNS_IP}
+
+    encode gzip
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}

--- a/src/technitium_dns/Caddyfile
+++ b/src/technitium_dns/Caddyfile
@@ -1,7 +1,6 @@
 dns.{env.DOMAIN_NAME} {
     reverse_proxy {env.TECHNITIUM_DNS_IP}
 
-
     tls {
         dns cloudflare {env.CLOUDFLARE_API_TOKEN}
     }


### PR DESCRIPTION
Introduces a Caddyfile configuration to reverse proxy DNS traffic to Technitium DNS, enable gzip encoding, and configure TLS using Cloudflare DNS with environment variables.