### PR TITLE
feat: add rustdesk configuration

### DIFF
--- a/src/rustdesk/Caddy
+++ b/src/rustdesk/Caddy
@@ -19,7 +19,7 @@
 	header @origin Access-Control-Allow-Methods "OPTIONS,GET,POST"
 }
 
-rustdesk.styves.io {
+rustdesk.{env.DOMAIN_NAME} {
 	# Put reverse proxy to same route to import shared header
 	route {
 		import header_common

--- a/src/rustdesk/Caddy
+++ b/src/rustdesk/Caddy
@@ -1,0 +1,43 @@
+(header_common) {
+	header {
+		# HSTS, very recommend to enable, for details, check https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security
+		# Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "same-origin"
+		Content-Security-Policy "base-uri 'self';"
+		X-Frame-Options "SAMEORIGIN"
+		X-XSS-Protection "1; mode=block"
+		# Remove reverse proxy header
+		-Server
+		-via
+	}
+}
+
+(cors) {
+	@origin header Origin {args[0]}
+	header @origin Access-Control-Allow-Origin "{args[0]}"
+	header @origin Access-Control-Allow-Methods "OPTIONS,GET,POST"
+}
+
+rustdesk.styves.io {
+	# Put reverse proxy to same route to import shared header
+	route {
+		import header_common
+		import cors rustdesk.com
+		encode zstd gzip
+
+		# ID Server
+		reverse_proxy /ws/id {env.CLUSTER_IP}:21118 {
+			transport http {
+				read_timeout 120s
+			}
+		}
+
+		# Relay Server
+		reverse_proxy /ws/relay {env.CLUSTER_IP}:21119 {
+			transport http {
+				read_timeout 120s
+			}
+		}
+	}
+}

--- a/src/rustdesk/docker-compose.yml
+++ b/src/rustdesk/docker-compose.yml
@@ -1,0 +1,34 @@
+networks:
+  rustdesk-net:
+    external: false
+
+services:
+  hbbs:
+    container_name: rustdesk_hhbs
+    ports:
+      - 21115:21115
+      - 21116:21116
+      - 21116:21116/udp
+      - 21118:21118
+    image: rustdesk/rustdesk-server
+    command: hbbs -r yourname.synology.me:21117
+    volumes:
+      - /volume1/docker/rustdeskhbbs:/root:rw
+    networks:
+      - rustdesk-net
+    depends_on:
+      - hbbr
+    restart: on-failure:5
+
+  hbbr:
+    container_name: rustdesk_hbbr
+    ports:
+      - 21117:21117
+      - 21119:21119
+    image: rustdesk/rustdesk-server
+    command: hbbr
+    volumes:
+      - /volume1/docker/rustdeskhbbr:/root:rw
+    networks:
+      - rustdesk-net
+    restart: on-failure:5

--- a/src/rustdesk/docker-compose.yml
+++ b/src/rustdesk/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     image: rustdesk/rustdesk-server
     command: hbbs -r yourname.synology.me:21117
     volumes:
-      - /volume1/docker/rustdeskhbbs:/root:rw
+      - ${APPDATA_LOCATION}/rustdeskhbbs:/root:rw
     networks:
       - rustdesk-net
     depends_on:
@@ -28,7 +28,7 @@ services:
     image: rustdesk/rustdesk-server
     command: hbbr
     volumes:
-      - /volume1/docker/rustdeskhbbr:/root:rw
+      - ${APPDATA_LOCATION}/rustdeskhbbr:/root:rw
     networks:
       - rustdesk-net
     restart: on-failure:5


### PR DESCRIPTION
This pull request introduces configuration files for deploying and securing the Rustdesk server infrastructure. The changes add a new Caddy server configuration to improve security and reverse proxy setup, and a `docker-compose.yml` file to orchestrate the Rustdesk backend services (`hbbs` and `hbbr`) with appropriate networking and restart policies.

**Infrastructure setup:**

* Added a new `docker-compose.yml` file to define and orchestrate the Rustdesk backend services (`hbbs` and `hbbr`), including port mapping, volumes, custom network, and restart policies.

**Security and proxy configuration:**

* Created a Caddy configuration file that sets secure HTTP headers, removes reverse proxy headers, and configures reverse proxy routes for Rustdesk ID and Relay servers with extended read timeouts.
* Implemented CORS handling in the Caddy configuration to allow cross-origin requests from a specified domain.