### PR TITLE
feat: add Caddyfile for WireGuard dashboard reverse proxy

### DIFF
--- a/src/wireguard/Caddyfile
+++ b/src/wireguard/Caddyfile
@@ -1,0 +1,9 @@
+vpndash.{env.DOMAIN_NAME} {
+    reverse_proxy {env.WIREGUARD_IP}:{env.WIREGUARD_DASHBOARD_PORT}
+
+    encode gzip
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}


### PR DESCRIPTION
Introduces a Caddyfile configuration to proxy requests to the WireGuard dashboard, enable gzip encoding, and set up TLS using Cloudflare DNS with environment variables.