### PR TITLE
feat: add syncthing

### DIFF
--- a/src/syncthing/docker-compose.yml
+++ b/src/syncthing/docker-compose.yml
@@ -2,17 +2,12 @@ services:
   syncthing:
     image: syncthing/syncthing
     container_name: syncthing
-    hostname: my-syncthing
+    network_mode: host
     environment:
       - PUID=1000
       - PGID=1000
     volumes:
       - ${APPDATA_LOCATION}/sync:/var/syncthing
-    ports:
-      - 8384:8384 # Web UI
-      - 22000:22000/tcp # TCP file transfers
-      - 22000:22000/udp # QUIC file transfers
-      - 21027:21027/udp # Receive local discovery broadcasts
     restart: unless-stopped
     healthcheck:
       test: curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1

--- a/src/syncthing/docker-compose.yml
+++ b/src/syncthing/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  syncthing:
+    image: syncthing/syncthing
+    container_name: syncthing
+    hostname: my-syncthing
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - ${APPDATA_LOCATION}/sync:/var/syncthing
+    ports:
+      - 8384:8384 # Web UI
+      - 22000:22000/tcp # TCP file transfers
+      - 22000:22000/udp # QUIC file transfers
+      - 21027:21027/udp # Receive local discovery broadcasts
+    restart: unless-stopped
+    healthcheck:
+      test: curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1
+      interval: 1m
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for running Syncthing as a containerized service. The main change is the addition of a `docker-compose.yml` file that defines how Syncthing should be deployed and managed.

New Syncthing service configuration:

* Added a `docker-compose.yml` file specifying a Syncthing service with the official image, host networking, environment variables for user/group IDs, and persistent volume mapping to `${APPDATA_LOCATION}/sync` for data storage.
* Included a healthcheck to monitor the Syncthing REST API, ensuring the service is running and healthy.
* Configured the container to automatically restart unless stopped manually, improving reliability.