### PR TITLE
feat: windows user rename

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = roles

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,8 @@
+windows:
+  hosts:
+    zues:
+      ansible_host: zues.olympus
+      ansible_user: ansible
+  vars:
+    ansible_connection: ssh
+    ansible_shell_type: powershell

--- a/inventory.yml
+++ b/inventory.yml
@@ -2,7 +2,9 @@ windows:
   hosts:
     zues:
       ansible_host: zues.olympus
-      ansible_user: ansible
+    hermes:
+      ansible_host: hermes.olympus
   vars:
+    ansible_user: ansible
     ansible_connection: ssh
     ansible_shell_type: powershell

--- a/playbooks/hermes.yml
+++ b/playbooks/hermes.yml
@@ -6,6 +6,7 @@
   roles:
   - role: system/windows_base
     vars:
+      hostname: Hermes
       users_to_rename:
       - old_username: 'astyv'
         new_username: 'andrew'

--- a/playbooks/hermes.yml
+++ b/playbooks/hermes.yml
@@ -1,6 +1,6 @@
 ---
-- name: Configure Zues
-  hosts: zues
+- name: Configure Hermes
+  hosts: hermes
   gather_facts: true
 
   roles:

--- a/playbooks/zues.yml
+++ b/playbooks/zues.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure Zues
+  hosts: zues
+  gather_facts: true
+
+  roles:
+  - role: system/windows/rename_user
+    vars:
+      current_username: astyv
+      new_username: andrew

--- a/playbooks/zues.yml
+++ b/playbooks/zues.yml
@@ -4,7 +4,8 @@
   gather_facts: true
 
   roles:
-  - role: system/windows/rename_user
+  - role: system/windows_base
     vars:
-      current_username: astyv
-      new_username: andrew
+      users_to_rename:
+      - current_username: 'astyv'
+        new_username: 'andrew'

--- a/playbooks/zues.yml
+++ b/playbooks/zues.yml
@@ -6,6 +6,7 @@
   roles:
   - role: system/windows_base
     vars:
+      hostname: Zues
       users_to_rename:
       - old_username: 'astyv'
         new_username: 'andrew'

--- a/roles/system/windows/rename_user/tasks/main.yml
+++ b/roles/system/windows/rename_user/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Rename user
+  ansible.windows.win_powershell:
+    script: |
+      $currentUsername = "{{ current_username }}"
+      $newUsername = "{{ new_username }}"
+
+      $currentUser = Get-LocalUser -Name $currentUsername -ErrorAction SilentlyContinue
+      $newUser = Get-LocalUser -Name $newUsername -ErrorAction SilentlyContinue
+
+      if ($currentUser -ne $null -and $newUser -eq $null) {
+        Write-Output "renamed"
+      }
+      else {
+        Write-Output "not renamed"
+      }
+  register: rename_result
+  changed_when: rename_result.output[0] == "renamed"
+
+# - name: Get SID and current profile path
+#   ansible.windows.win_powershell:
+#     script: |
+#       $uName = "{{ old_username }}"
+#       $sid = (Get-LocalUser -Name $uName).Sid.Value
+#       $profKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
+#       $prof = Get-ItemProperty -Path $profKey
+#       [pscustomobject]@{
+#         SID = $sid
+#         CurrentProfilePath = $prof.ProfileImagePath
+#       }
+#   register: user_info
+
+# - name: Set facts
+#   ansible.builtin.set_fact:
+#     target_sid: "{{ user_info.output[0].SID }}"
+#     current_profile_path: "{{ user_info.output[0].CurrentProfilePath }}"
+#     new_profile_path: "{{ users_root }}\\{{ new_username }}"
+
+# - name: Rename profile folder on disk
+#   ansible.windows.win_powershell:
+#     script: |
+#       Rename-Item -LiteralPath "{{ current_profile_path }}" -NewName "{{ new_username }}"
+#   when: current_profile_path | lower != new_profile_path | lower
+
+# - name: Update registry ProfileImagePath
+#   ansible.windows.win_regedit:
+#     path: "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{{ target_sid }}"
+#     name: "ProfileImagePath"
+#     data: "{{ new_profile_path }}"
+#     type: string
+
+# - name: Fix ACLs on new profile folder
+#   ansible.windows.win_powershell:
+#     script: |
+#       $path = "{{ new_profile_path }}"
+#       $user = "{{ new_username }}"
+#       & takeown.exe /F $path /R /D Y | Out-Null
+#       icacls $path /grant:r "$env:COMPUTERNAME\$user:(OI)(CI)(F)" /T | Out-Null

--- a/roles/system/windows_base/defaults/main.yml
+++ b/roles/system/windows_base/defaults/main.yml
@@ -1,0 +1,4 @@
+# defaults file for roles/system/windows_base
+users_to_rename:
+  - current_username: 'ansible'
+    new_username: 'ansible'

--- a/roles/system/windows_base/defaults/main.yml
+++ b/roles/system/windows_base/defaults/main.yml
@@ -1,4 +1,6 @@
 # defaults file for roles/system/windows_base
+hostname: ansible
+
 users_to_rename:
   - old_username: 'ansible'
     new_username: 'ansible'

--- a/roles/system/windows_base/defaults/main.yml
+++ b/roles/system/windows_base/defaults/main.yml
@@ -1,4 +1,4 @@
 # defaults file for roles/system/windows_base
 users_to_rename:
-  - current_username: 'ansible'
+  - old_username: 'ansible'
     new_username: 'ansible'

--- a/roles/system/windows_base/handlers/main.yml
+++ b/roles/system/windows_base/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Reboot Windows
+  ansible.windows.win_reboot:
+    reboot_timeout: 1800
+    post_reboot_delay: 30

--- a/roles/system/windows_base/tasks/main.yml
+++ b/roles/system/windows_base/tasks/main.yml
@@ -1,60 +1,117 @@
----
 - name: Rename user
   ansible.windows.win_powershell:
     script: |
-      $currentUsername = "{{ item.current_username }}"
+      $oldUsername = "{{ item.old_username }}"
       $newUsername = "{{ item.new_username }}"
 
-      $currentUser = Get-LocalUser -Name $currentUsername -ErrorAction SilentlyContinue
+      $oldUser = Get-LocalUser -Name $oldUsername -ErrorAction SilentlyContinue
       $newUser = Get-LocalUser -Name $newUsername -ErrorAction SilentlyContinue
 
-      if ($currentUser -ne $null -and $newUser -eq $null) {
-        Write-Output "renamed"
+      $renamed = $false
+
+      if ($oldUser -ne $null -and $newUser -eq $null) {
+        Rename-LocalUser -Name "$oldUsername" -NewName "$newUsername"
+        $renamed = $true 
       }
-      else {
-        Write-Output "not renamed"
+
+      Write-Output @{
+        old_username = $oldUsername
+        new_username = $newUsername
+        renamed = $renamed
       }
-  register: rename_result
-  changed_when: rename_result.output[0] == "renamed"
+  register: windows_base_rename_user_result
+  changed_when: windows_base_rename_user_result.output[0].renamed == "true"
   loop: "{{ users_to_rename }}"
   notify: Reboot Windows
 
-- name: Rename profile folder on disk
-  ansible.windows.win_powershell:
-    script: |
-      $username = "{{ item.new_username }}"
-      $sid = (Get-LocalUser -Name $username).Sid.Value
-      $profKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
-      $profilePath = (Get-ItemProperty -Path $profKey).ProfileImagePath
-      $newProfilePath = "{{ users_root }}\\{{ $username }}"
+#========================================================
+# DANGER: NEEDS MANUAL VALIDATION
+#=========================================================
 
-      if ($profilePath -ne $newProfilePath) {
-        Write-Output "renamed"
-      }
-      else {
-        Write-Output "not renamed"
-      }
-  register: profile_folder_rename_result
-  changed_when: rename_result.output[0] == "renamed"
-  loop: "{{ users_to_rename }}"
-  notify: Reboot Windows
-
-- name: Update registry ProfileImagePath
-  ansible.windows.win_regedit:
-    path: "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{{ target_sid }}"
-    name: "ProfileImagePath"
-    data: "{{ new_profile_path }}"
-    type: string
-  notify: Reboot Windows
-  loop: "{{ users_to_rename }}"
-
-# - name: Fix ACLs on new profile folder
+# - name: Get profile facts
 #   ansible.windows.win_powershell:
 #     script: |
-#       $path = "{{ new_profile_path }}"
-#       $user = "{{ new_username }}"
-#       & takeown.exe /F $path /R /D Y | Out-Null
-#       icacls $path /grant:r "$env:COMPUTERNAME\$user:(OI)(CI)(F)" /T | Out-Null
+#       $profile = @{
+#         exists = (Get-LocalUser -Name "{{ item.new_username }}" -ErrorAction Ignore) -as [bool]
+#         username = $null
+#         sid = $null
+#         profile_reg_key = $null
+#         old_path = $null
+#         new_path = $null
+#       }
+
+#       if ($profile.exists)
+#       {
+#         $profile.username = "{{ item.new_username }}"
+#         $profile.sid = (Get-LocalUser -Name $profile.username).Sid.Value
+#         $profile.profile_reg_key = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
+#         $profile.old_path = (Get-ItemProperty -Path $profile.profile_reg_key).ProfileImagePath    
+        
+#         $parentProfilePath = Split-Path -Path $profile.old_path -Parent
+#         $profile.new_path = Join-Path -Path $parentProfilePath -ChildPath $profile.username
+#       }
+
+#       Write-Output $profile
+#   register: windows_base_profile_facts
+#   loop: "{{ users_to_rename }}"
+#   changed_when: false
+#   check_mode: false
+
+# - name: Rename profile folder on disk
+#   ansible.windows.win_powershell:
+#     script: |
+#       $result = @{
+#         old_path = "{{ item.old_path }}"
+#         new_path = "{{ item.new_path }}"
+#         renamed = $false
+#       }
+
+#       if ($result.old_path -ne $result.new_path)
+#       {
+#         Rename-Item -Path $result.old_path -NewName $result.new_path
+#         $result.renamed = $true
+#       }
+
+#       Write-Output $result
+#   register: windows_profile_folder_rename_result
+#   changed_when: windows_profile_folder_rename_result.output[0].renamed == "true"
+#   when: item.exists
+#   loop: "{{ windows_base_profile_facts.results | map(attribute='output') | list | flatten }}"
+#   notify: Reboot Windows
+
+# - name: Update registry ProfileImagePath
+#   ansible.windows.win_regedit:
+#     path: "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{{ item.sid }}"
+#     name: "ProfileImagePath"
+#     data: "{{ item.new_path }}"
+#     type: string
+#   when: item.exists
+#   loop: "{{ windows_base_profile_facts.results | map(attribute='output') | list | flatten }}"
+#   check_mode: true
+#   notify: Reboot Windows
+
+#========================================================
+# END OF DANGER
+#=========================================================
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
+
+- name: Ensure DNS global suffix list is set
+  ansible.windows.win_powershell:
+    script: |
+      $result = @{
+        changed = $false
+      }
+
+      $suffixes = @("olympus")
+      $current = (Get-DnsClientGlobalSetting).SuffixSearchList
+
+      if (-not (Compare-Object $suffixes $current)) {
+          Set-DnsClientGlobalSetting -SuffixSearchList $suffixes
+          $result.changed = $true
+      }
+
+      Write-Output $result
+  register: windows_base_set_dns_suffix_list_result
+  changed_when: windows_base_set_dns_suffix_list_result.output[0].changed == "true"

--- a/roles/system/windows_base/tasks/main.yml
+++ b/roles/system/windows_base/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Set the computer hostname
+  win_hostname:
+    name: "{{ hostname }}"
+  notify: Reboot Windows
+
 - name: Rename user
   ansible.windows.win_powershell:
     script: |
@@ -93,9 +98,6 @@
 #========================================================
 # END OF DANGER
 #=========================================================
-
-- name: Flush handlers
-  ansible.builtin.meta: flush_handlers
 
 - name: Ensure DNS global suffix list is set
   ansible.windows.win_powershell:

--- a/roles/system/windows_base/tasks/main.yml
+++ b/roles/system/windows_base/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Rename user
   ansible.windows.win_powershell:
     script: |
-      $currentUsername = "{{ current_username }}"
-      $newUsername = "{{ new_username }}"
+      $currentUsername = "{{ item.current_username }}"
+      $newUsername = "{{ item.new_username }}"
 
       $currentUser = Get-LocalUser -Name $currentUsername -ErrorAction SilentlyContinue
       $newUser = Get-LocalUser -Name $newUsername -ErrorAction SilentlyContinue
@@ -16,6 +16,8 @@
       }
   register: rename_result
   changed_when: rename_result.output[0] == "renamed"
+  loop: "{{ users_to_rename }}"
+  notify: Reboot Windows
 
 # - name: Get SID and current profile path
 #   ansible.windows.win_powershell:
@@ -56,3 +58,6 @@
 #       $user = "{{ new_username }}"
 #       & takeown.exe /F $path /R /D Y | Out-Null
 #       icacls $path /grant:r "$env:COMPUTERNAME\$user:(OI)(CI)(F)" /T | Out-Null
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/system/windows_base/tasks/main.yml
+++ b/roles/system/windows_base/tasks/main.yml
@@ -19,37 +19,34 @@
   loop: "{{ users_to_rename }}"
   notify: Reboot Windows
 
-# - name: Get SID and current profile path
-#   ansible.windows.win_powershell:
-#     script: |
-#       $uName = "{{ old_username }}"
-#       $sid = (Get-LocalUser -Name $uName).Sid.Value
-#       $profKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
-#       $prof = Get-ItemProperty -Path $profKey
-#       [pscustomobject]@{
-#         SID = $sid
-#         CurrentProfilePath = $prof.ProfileImagePath
-#       }
-#   register: user_info
+- name: Rename profile folder on disk
+  ansible.windows.win_powershell:
+    script: |
+      $username = "{{ item.new_username }}"
+      $sid = (Get-LocalUser -Name $username).Sid.Value
+      $profKey = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\$sid"
+      $profilePath = (Get-ItemProperty -Path $profKey).ProfileImagePath
+      $newProfilePath = "{{ users_root }}\\{{ $username }}"
 
-# - name: Set facts
-#   ansible.builtin.set_fact:
-#     target_sid: "{{ user_info.output[0].SID }}"
-#     current_profile_path: "{{ user_info.output[0].CurrentProfilePath }}"
-#     new_profile_path: "{{ users_root }}\\{{ new_username }}"
+      if ($profilePath -ne $newProfilePath) {
+        Write-Output "renamed"
+      }
+      else {
+        Write-Output "not renamed"
+      }
+  register: profile_folder_rename_result
+  changed_when: rename_result.output[0] == "renamed"
+  loop: "{{ users_to_rename }}"
+  notify: Reboot Windows
 
-# - name: Rename profile folder on disk
-#   ansible.windows.win_powershell:
-#     script: |
-#       Rename-Item -LiteralPath "{{ current_profile_path }}" -NewName "{{ new_username }}"
-#   when: current_profile_path | lower != new_profile_path | lower
-
-# - name: Update registry ProfileImagePath
-#   ansible.windows.win_regedit:
-#     path: "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{{ target_sid }}"
-#     name: "ProfileImagePath"
-#     data: "{{ new_profile_path }}"
-#     type: string
+- name: Update registry ProfileImagePath
+  ansible.windows.win_regedit:
+    path: "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\{{ target_sid }}"
+    name: "ProfileImagePath"
+    data: "{{ new_profile_path }}"
+    type: string
+  notify: Reboot Windows
+  loop: "{{ users_to_rename }}"
 
 # - name: Fix ACLs on new profile folder
 #   ansible.windows.win_powershell:

--- a/scripts/prep_ubuntu_control_node.sh
+++ b/scripts/prep_ubuntu_control_node.sh
@@ -23,6 +23,12 @@ echo "✅ Ansible installation completed."
 ansible --version
 
 # =======================================
+# Install git
+# =======================================
+
+sudo apt install git
+
+# =======================================
 # SSH Key setup
 # =======================================
 
@@ -37,3 +43,5 @@ else
 fi
 echo "Private key: $SSH_KEY"
 echo "Public key : ${SSH_KEY}.pub"
+
+cat "${SSH_KEY}.pub"

--- a/scripts/prep_windows_node.ps1
+++ b/scripts/prep_windows_node.ps1
@@ -2,10 +2,48 @@
 # https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5
 # winget install --id Microsoft.PowerShell --source winget 
 
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [Security.SecureString]$AnsibleUserPassword
+)
+
+# -----------------------------------------------------------------------
+# Creat new `ansible` user account and add to Admin group
+# -----------------------------------------------------------------------
+Write-Host "🔄 Creating new 'ansible' user..."
+
+$ansibleUser = @{
+    Name        = 'ansible'
+    Password    = $AnsibleUserPassword
+    FullName    = 'Ansible'
+    Description = 'Default account used by Ansible during a play.'
+}
+
+$user = Get-LocalUser -Name $ansibleUser.Name -ErrorAction SilentlyContinue
+
+if (-not $user) {
+    New-LocalUser @ansibleUser
+    Write-Output "✅ 'ansible' user created."
+}
+else
+{
+    Write-Output "ℹ️ No Change: 'ansible' user already exists."
+}
+
+$isAdmin = Get-LocalGroupMember -Group "Administrators" -Member $ansibleUser.Name -ErrorAction SilentlyContinue
+
+if (-not $isAdmin) {
+    Add-LocalGroupMember -Group "Administrators" -Member $ansibleUser.Name
+    Write-Output "✅ 'ansible' user added to Administrators group."
+}
+else
+{
+    Write-Output "ℹ️ No Change: 'ansible' user already in the Administrators group."
+}
+
 # -----------------------------------------------------------------------
 # OpenSSH Setup
-#
-# REQUIRED - Configure OpenSSH for Windows
 # -----------------------------------------------------------------------
 Write-Host "🔄 Setting up OpenSSH..."
 
@@ -25,7 +63,7 @@ if (Get-Service -Name sshd -ErrorAction SilentlyContinue) {
     }
     else
     {
-        Write-Output "ℹ️ sshd already running."
+        Write-Output "ℹ️ No Change: sshd already running."
     }
 
     $startupType = (Get-WmiObject -Class Win32_Service -Filter "Name='sshd'").StartMode
@@ -35,12 +73,13 @@ if (Get-Service -Name sshd -ErrorAction SilentlyContinue) {
     }
     else 
     {
-        Write-Output "ℹ️ sshd service auto start already configured."
+        Write-Output "ℹ️ No Change: sshd service auto start already configured."
     }
 
 
 } else {
     Write-Host "❌ sshd service not found."
+    exit 1
 }
 
 
@@ -55,7 +94,7 @@ if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyCon
 
     Write-Output "✅ Firewall rules configured."
 } else {
-    Write-Output "ℹ️ Firewall rule 'OpenSSH-Server-In-TCP' already exists. No change needed."
+    Write-Output "ℹ️ No Change: Firewall rule 'OpenSSH-Server-In-TCP' already exists."
 }
 
 # -----------------------------------------------------------------------
@@ -83,7 +122,7 @@ if ($currentValue -ne $newValue) {
     Set-ItemProperty -Path $regPath -Name $regName -Value $newValue
     Write-Output "✅ Default SSH Shell set to PowerShell 7."
 } else {
-    Write-Output "ℹ️ Default SSH Shell is already set to PowerShell 7. No change needed."
+    Write-Output "ℹ️ No Change: default SSH Shell is already set to PowerShell 7."
 }
 
 # create administrators_authorized_keys if not exists
@@ -101,7 +140,7 @@ if (-not (Test-Path $authKeysFile)) {
 
     Write-Output "✅ SSH authorized key files ready."
 } else {
-    Write-Host "ℹ️ administrators_authorized_keys already exists."
+    Write-Host "ℹ️ No Change: 'administrators_authorized_keys' already exists."
 }
 
 # -----------------------------------------------------------------------

--- a/scripts/prep_windows_node.ps1
+++ b/scripts/prep_windows_node.ps1
@@ -8,9 +8,9 @@ param (
     [Security.SecureString]$AnsibleUserPassword
 )
 
-# -----------------------------------------------------------------------
+# =======================================================================
 # Creat new `ansible` user account and add to Admin group
-# -----------------------------------------------------------------------
+# =======================================================================
 Write-Host "🔄 Creating new 'ansible' user..."
 
 $ansibleUser = @{
@@ -42,9 +42,9 @@ else
     Write-Output "ℹ️ No Change: 'ansible' user already in the Administrators group."
 }
 
-# -----------------------------------------------------------------------
+# =======================================================================
 # OpenSSH Setup
-# -----------------------------------------------------------------------
+# =======================================================================
 Write-Host "🔄 Setting up OpenSSH..."
 
 Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
@@ -97,12 +97,12 @@ if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyCon
     Write-Output "ℹ️ No Change: Firewall rule 'OpenSSH-Server-In-TCP' already exists."
 }
 
-# -----------------------------------------------------------------------
+# =======================================================================
 # OpenSSH Configuration
 #
 # ✅ Set default SSH shell to PowerShell 7
 # ✅ Configure SSH authorized key files.
-# -----------------------------------------------------------------------
+# =======================================================================
 
 $regPath  = 'HKLM:\SOFTWARE\OpenSSH'
 $regName  = 'DefaultShell'
@@ -143,11 +143,11 @@ if (-not (Test-Path $authKeysFile)) {
     Write-Host "ℹ️ No Change: 'administrators_authorized_keys' already exists."
 }
 
-# -----------------------------------------------------------------------
+# =======================================================================
 # WSL2 Setup
 # 
 # OPTIONAL - Ensure that WSL2 is ready if we need a control node
-# -----------------------------------------------------------------------
+# =======================================================================
 
 $wslInput = Read-Host "`n🐧 Setup WSL2? (Yes/No)"
 if ($wslInput.Trim().ToLower() -eq 'yes' -or $wslInput.Trim().ToLower() -eq 'y') {


### PR DESCRIPTION
This pull request introduces a Windows automation setup using Ansible, including new roles, playbooks, and supporting configuration. The main goal is to enable the configuration and management of Windows hosts (`zues` and `hermes`) via Ansible, with scripts to prepare both Ubuntu control nodes and Windows target nodes for automation.

**Ansible Windows automation setup**

* Added `inventory.yml` with Windows hosts `zues` and `hermes`, including SSH configuration and PowerShell shell type for Ansible connections.
* Created playbooks `playbooks/zues.yml` and `playbooks/hermes.yml` to configure each Windows host using the new `system/windows_base` role, including user renaming and hostname setting.

**Configuration and setup improvements**

* Added `ansible.cfg` with `roles_path` set to `roles` for easier role management.
* Updated `scripts/prep_ubuntu_control_node.sh` to install `git` and display SSH public key after creation.

**Windows node preparation script enhancements**

* Major update to `scripts/prep_windows_node.ps1`: now accepts an `AnsibleUserPassword` parameter, creates and configures the `ansible` user, improves OpenSSH setup, clarifies output messages, enforces error handling, and adds optional WSL2 setup.