### PR TITLE
feat add Plex service configuration and Caddyfile

### DIFF
--- a/src/plex/Caddyfile
+++ b/src/plex/Caddyfile
@@ -1,0 +1,17 @@
+plex.{env.DOMAIN_NAME} {
+    header {
+        Strict-Transport-Security max-age=31536000;
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy no-referrer-when-downgrade
+        X-XSS-Protection 1
+    }
+
+    reverse_proxy {env.CLUSTER_IP}:{env.PLEX_PORT}
+    
+    encode gzip zstd
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}    

--- a/src/plex/docker-compose.yml
+++ b/src/plex/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  plex:
+    container_name: plex
+    image: plexinc/pms-docker:1.42.1.10060-4e8b05daf
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ}
+    network_mode: host
+    volumes:
+      - ${APPDATA_LOCATION}/plex/config:/config
+      - ${MEDIA_LOCATION}:/data
+      - /dev/shm/plex/transcode:/transcode
+    deploy:
+     resources:
+       reservations:
+         devices:
+           - driver: nvidia
+             count: 1
+             capabilities: [gpu]


### PR DESCRIPTION
This pull request sets up the Plex media server as a new service in the project, including its deployment configuration and secure reverse proxy settings. The main changes are the addition of a Caddy reverse proxy configuration for Plex and a Docker Compose service definition for running Plex with GPU support.

**Reverse Proxy and Security Configuration:**

* Added a new Caddyfile entry (`src/plex/Caddyfile`) to proxy requests to Plex, including strict security headers and TLS configuration using Cloudflare DNS.

**Plex Service Deployment:**

* Introduced a Docker Compose file (`src/plex/docker-compose.yml`) defining the Plex service, with host networking, persistent storage volumes, timezone configuration, and deployment settings to reserve an NVIDIA GPU for hardware acceleration.