### PR TITLE
feat: add romm compose and caddy config

### DIFF
--- a/src/romm/Caddyfile
+++ b/src/romm/Caddyfile
@@ -1,0 +1,15 @@
+romm.{env.DOMAIN_NAME} {
+    reverse_proxy {env.CLUSTER_IP}:7456
+
+    header {
+        X-Frame-Options "SAMEORIGIN"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "strict-origin-when-cross-origin"
+    }
+
+    encode gzip
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}

--- a/src/romm/docker-compose.yml
+++ b/src/romm/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_PASSWORD}
       MARIADB_DATABASE: romm
-      MARIADB_USER: romm-user
+      MARIADB_USER: ${MARIADB_USER}
       MARIADB_PASSWORD: ${MARIADB_PASSWORD}
     volumes:
       - mysql_data:/var/lib/mysql
@@ -19,13 +19,13 @@ services:
       retries: 5
 
   romm:
-    image: rommapp/romm:latest
+    image: rommapp/romm:4.0.1
     container_name: romm
     restart: unless-stopped
     environment:
       DB_HOST: romm-db
       DB_NAME: romm
-      DB_USER: romm-user
+      DB_USER: ${MARIADB_USER}
       DB_PASSWD: ${MARIADB_PASSWORD}
       ROMM_AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
       IGDB_CLIENT_ID: u66kwnyvkxtyb5y9d9v1olnrymz1d6
@@ -34,6 +34,7 @@ services:
       SCREENSCRAPER_PASSWORD: ${SCREENSCRAPER_PASSWORD}
       RETROACHIEVEMENTS_API_KEY: ${RETROACHIEVEMENTS_API_KEY}
       STEAMGRIDDB_API_KEY: ${STEAMGRIDDB_API_KEY}
+      HASHEOUS_API_ENABLED: true
       OIDC_ENABLED: true
       OIDC_PROVIDER: Authentik
       OIDC_CLIENT_ID: rw7NEhIIx6OQ6uGYhRzmuNRm73F48IQrCp0EaQFx

--- a/src/romm/docker-compose.yml
+++ b/src/romm/docker-compose.yml
@@ -1,0 +1,63 @@
+services:
+  romm-db:
+    image: mariadb:latest
+    container_name: romm_db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MARIADB_PASSWORD}
+      MARIADB_DATABASE: romm
+      MARIADB_USER: romm-user
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: [ CMD, healthcheck.sh, --connect, --innodb_initialized ]
+      start_period: 30s
+      start_interval: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  romm:
+    image: rommapp/romm:latest
+    container_name: romm
+    restart: unless-stopped
+    environment:
+      DB_HOST: romm-db
+      DB_NAME: romm
+      DB_USER: romm-user
+      DB_PASSWD: ${MARIADB_PASSWORD}
+      ROMM_AUTH_SECRET_KEY: ${AUTH_SECRET_KEY}
+      IGDB_CLIENT_ID: u66kwnyvkxtyb5y9d9v1olnrymz1d6
+      IGDB_CLIENT_SECRET: ${IGDB_CLIENT_SECRET}
+      SCREENSCRAPER_USER: CicerosPatience
+      SCREENSCRAPER_PASSWORD: ${SCREENSCRAPER_PASSWORD}
+      RETROACHIEVEMENTS_API_KEY: ${RETROACHIEVEMENTS_API_KEY}
+      STEAMGRIDDB_API_KEY: ${STEAMGRIDDB_API_KEY}
+      OIDC_ENABLED: true
+      OIDC_PROVIDER: Authentik
+      OIDC_CLIENT_ID: rw7NEhIIx6OQ6uGYhRzmuNRm73F48IQrCp0EaQFx
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
+      OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI}
+      OIDC_SERVER_APPLICATION_URL: ${OIDC_SERVER_APPLICATION_URL}
+    volumes:
+      - ${APPDATA_LOCATION}/romm/resources:/romm/resources
+      - ${APPDATA_LOCATION}/romm/redis:/redis-data
+      - ${MEDIA_LOCATION}/games:/romm/library
+      - ${APPDATA_LOCATION}/romm/assets:/romm/assets
+      - ${APPDATA_LOCATION}/romm/config:/romm/config
+    ports:
+      - 7456:8080
+    depends_on:
+      romm-db:
+        condition: service_healthy
+        restart: true
+
+volumes:
+  mysql_data: 
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${APPDATA_LOCATION}/romm/mariadb
+  


### PR DESCRIPTION
This pull request introduces configuration files to support deploying the ROMM application and its database using Docker Compose, and adds a Caddy reverse proxy setup for secure and optimized access. The main changes are the addition of service definitions and environment variable usage for flexible deployment.

**Deployment configuration:**

* Added `docker-compose.yml` for ROMM, including a `romm-db` service using the `mariadb:latest` image with healthchecks, and a `romm` service using the `rommapp/romm:4.0.1` image, with environment variables for database and third-party integrations, volume mounts for persistent data, and service dependency management.
* Defined a persistent volume `mysql_data` for MariaDB with bind mount options to store data in a specified host directory.

**Reverse proxy and security:**

* Added a `Caddyfile` configuration for the ROMM service, setting up reverse proxying to the application, enabling gzip encoding, enforcing security headers, and configuring TLS with Cloudflare DNS for certificate management.