### PR TITLE
feat: update various dependencies and applications

### DIFF
--- a/src/actual_budget/docker-compose.yml
+++ b/src/actual_budget/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   actual_server:
-    image: actualbudget/actual-server:26.2.0
+    image: actualbudget/actual-server:26.5.2
     container_name: actual_budget
     security_opt:
       - no-new-privileges:true

--- a/src/audiobookshelf/docker-compose.yml
+++ b/src/audiobookshelf/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   audiobookshelf:
     container_name: audiobookshelf
-    image: advplyr/audiobookshelf:2.32.1
+    image: advplyr/audiobookshelf:2.34.0
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 80 || exit 1"]
       interval: 10s

--- a/src/authentik/docker-compose.yml
+++ b/src/authentik/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - redis:/data
 
   server:
-    image: ghcr.io/goauthentik/server:2025.12.4
+    image: ghcr.io/goauthentik/server:2026.2.3
     container_name: authentik
     restart: unless-stopped
     command: server
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
 
   worker:
-    image: ghcr.io/goauthentik/server:2025.12.4
+    image: ghcr.io/goauthentik/server:2026.2.3
     container_name: authentik_worker
     restart: unless-stopped
     command: worker

--- a/src/forgejo/docker-compose.yml
+++ b/src/forgejo/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     restart: on-failure:5
 
   server:
-    image: codeberg.org/forgejo/forgejo:14.0.3
+    image: codeberg.org/forgejo/forgejo:15.0.2
     container_name: forgejo
     hostname: forgejo
     security_opt:

--- a/src/home_assistant/docker-compose.yml
+++ b/src/home_assistant/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2026.2.3
+    image: homeassistant/home-assistant:2026.5.2
     container_name: home_assistant
     mem_limit: 8g
     cpu_shares: 768

--- a/src/plex/docker-compose.yml
+++ b/src/plex/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   plex:
     container_name: plex
-    image: plexinc/pms-docker:1.42.2.10156-f737b826c
+    image: plexinc/pms-docker:1.43.1.10611-1e34174b1
     restart: unless-stopped
     environment:
       - PLEX_UID=${PUID}

--- a/src/romm/docker-compose.yml
+++ b/src/romm/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   romm:
-    image: rommapp/romm:4.6.1
+    image: rommapp/romm:4.8.1
     container_name: romm
     restart: unless-stopped
     environment:

--- a/src/syncthing/docker-compose.yml
+++ b/src/syncthing/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   syncthing:
-    image: syncthing/syncthing:2.0.14
+    image: syncthing/syncthing:2.1.0
     container_name: syncthing
     network_mode: host
     environment:

--- a/src/uptime-kuma/docker-compose.yml
+++ b/src/uptime-kuma/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   uptime-kuma:
     container_name: uptime-kuma
-    image: louislam/uptime-kuma:2.1.3
+    image: louislam/uptime-kuma:2.3.2
     restart: unless-stopped
     volumes:
       - app_data:/app/data


### PR DESCRIPTION
This pull request updates the Docker image versions for several core services to bring them up to date with their latest stable releases. These changes primarily focus on keeping the environment secure and benefiting from upstream bug fixes and new features.

**Service image updates:**

* Home automation and infrastructure:
  * Upgraded `homeassistant` to version `2026.5.2` for the latest features and security patches.
  * Updated `syncthing` to version `2.1.0` for improved syncing and bug fixes.
  * Updated `uptime-kuma` to version `2.3.2` for enhanced monitoring capabilities.

* Media and content management:
  * Updated `plex` to version `1.43.1.10611-1e34174b1` for new features and fixes.
  * Upgraded `audiobookshelf` to version `2.34.0` for stability and improvements.
  * Updated `romm` to version `4.8.1` for the latest enhancements.

* Authentication and budget management:
  * Upgraded `authentik` server and worker to version `2026.2.3` for security and reliability.
  * Updated `actual_server` to version `26.5.2` for bug fixes and improvements.

* Source control:
  * Upgraded `forgejo` server to version `15.0.2` for new features and bug fixes.