### PR TITLE
feat: add memos

### DIFF
--- a/src/memos/Caddyfile
+++ b/src/memos/Caddyfile
@@ -1,0 +1,9 @@
+memos.{env.DOMAIN_NAME} {
+    reverse_proxy {env.CLUSTER_IP}:5230
+
+    encode gzip
+
+    tls {
+        dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+    }
+}

--- a/src/memos/docker-compose.yml
+++ b/src/memos/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  memos:
+    image: neosmemo/memos:0.29.1
+    container_name: memos
+    restart: unless-stopped
+    ports:
+      - "5230:5230"
+    volumes:
+      - ${APPDATA_LOCATION}:/var/opt/memos
+    environment:
+      MEMOS_PORT: 5230
+      MEMOS_DRIVER: sqlite
+      MEMOS_INSTANCE_URL: https://memos.${DOMAIN}


### PR DESCRIPTION
This pull request introduces configuration files to deploy the Memos application using Docker Compose and Caddy for reverse proxy and TLS termination. The main changes set up the Memos service container, persistent storage, environment variables, and secure HTTPS access via Cloudflare DNS.

**Memos service deployment:**

* Added `docker-compose.yml` to define a `memos` service using the `neosmemo/memos:0.29.1` image, mapping port 5230, mounting persistent storage, and configuring environment variables for database and instance URL.

**Reverse proxy and HTTPS configuration:**

* Added a `Caddyfile` configuration to proxy traffic for `memos.{env.DOMAIN_NAME}` to the Memos container, enable gzip encoding, and set up automatic TLS with Cloudflare DNS using an API token.